### PR TITLE
Added "main" property so that bower component works with grunt-wiredep

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,6 +8,7 @@
     "name": "\"Cowboy\" Ben Alman",
     "url": "http://benalman.com/"
   },
+  "main": "dist/ba-tiny-pubsub.min.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/cowboy/jquery-tiny-pubsub.git"


### PR DESCRIPTION
As the bower standards demand a "main" property that points to a disted file, grunt tasks such as wiredep won't work without it. This adds support.
